### PR TITLE
Allow generating a help page via clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "anstream"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c4c2c83f81532e5845a733998b6971faca23490340a418e9b72a3ec9de12ea"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -60,6 +108,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "clap"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a13b88d2c62ff462f88e4a121f17a82c1af05693a2f192b5c38d14de73c19f6"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bb9faaa7c2ef94b2743a21f5a29e6f0010dff4caa69ac8e9d6cf8b6fa74da08"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,6 +182,12 @@ name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -301,6 +401,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "2.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -433,6 +539,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,6 +649,7 @@ name = "yjq"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "serde_json",
  "serde_yaml",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ path = "yq.rs"
 
 [dependencies]
 anyhow = "1.0.75"
+clap = { version = "4.4.2", features = ["derive"] }
 serde_json = "1.0.105"
 serde_yaml = "0.9.25"
 tokio = { version = "1.32.0", features = ["macros", "fs", "process","rt-multi-thread", "io-util"] }

--- a/yq.rs
+++ b/yq.rs
@@ -5,25 +5,43 @@ use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
 use tracing::*;
 
+use clap::Parser;
+#[derive(Parser, Debug)]
+struct Args {
+    /// Transcode jq JSON output into YAML and emit it
+    #[arg(short = 'e', long, default_value = "false")]
+    yaml_output: bool,
+    /// Arguments passed to jq
+    anonymous: Vec<String>,
+}
+
+
 #[tokio::main]
 async fn main() -> Result<()> {
+    let args = Args::parse();
+    println!("args: {:?}", args);
     tracing_subscriber::fmt().with_max_level(Level::INFO).init();
     // pass on args, skip arg 0 (which is yq)
-    let raw_args = std::env::args().skip(1).collect::<Vec<_>>();
+    let yaml_roundtrip = std::env::args().any(|x| x == "-y");
+    let mut args = std::env::args().skip(1).filter(|x| x != "-y").collect::<Vec<_>>();
     // read file input either from file or stdin
-    let (input, args) = read_input_yaml(raw_args).await?;
-    let output = shellout(input, args).await?;
+    let input = read_input_yaml(&mut args).await?;
+    let stdout = shellout(input, &args).await?;
+
+    // print output either as yaml or json (as per jq output)
+    let output = if yaml_roundtrip {
+        let val: serde_json::Value = serde_json::from_slice(&stdout)?;
+        serde_yaml::to_string(&val)?
+    } else {
+        String::from_utf8_lossy(&stdout).to_string()
+    };
+
     println!("{}", output);
     Ok(())
 }
 
-async fn shellout(input: Vec<u8>, all_args: Vec<String>) -> Result<String> {
-    let yaml_roundtrip = all_args.contains(&"-y".to_string());
-    let args = all_args
-        .into_iter()
-        .filter(|x| x != "-y") // yq only arg
-        .collect::<Vec<_>>();
-
+/// Pass json encoded bytes to jq with arguments for jq
+async fn shellout(input: Vec<u8>, args: &[String]) -> Result<Vec<u8>> {
     debug!("args: {:?}", args);
     // shellout jq with given args
     let mut child = Command::new("jq")
@@ -38,23 +56,15 @@ async fn shellout(input: Vec<u8>, all_args: Vec<String>) -> Result<String> {
     drop(stdin);
     // then wait for exit and gather output
     let stdout = child.wait_with_output().await?.stdout;
-    // print output either as yaml or json (as per jq output)
-    Ok(if yaml_roundtrip {
-        let val: serde_json::Value = serde_json::from_slice(&stdout)?;
-        serde_yaml::to_string(&val)?
-    } else {
-        String::from_utf8_lossy(&stdout).to_string()
-    })
+    Ok(stdout)
 }
 
 /// Convert yaml input into vector of json encoded bytes
-///
-/// if last arg is a file arg, we remove it from the args
-async fn read_input_yaml(mut args: Vec<String>) -> Result<(Vec<u8>, Vec<String>)> {
+async fn read_input_yaml(args: &mut Vec<String>) -> Result<Vec<u8>> {
     let contents; // long lived scope for file case
     let yaml_de = if let Some(last) = args.clone().last() {
         if let Ok(true) = tokio::fs::try_exists(last).await {
-            args.pop(); // don't pass the file arg to jq
+            args.pop(); // don't pass the file arg to jq if we read the file
             contents = tokio::fs::read_to_string(last).await?;
             Deserializer::from_str(&contents)
         } else {
@@ -70,7 +80,7 @@ async fn read_input_yaml(mut args: Vec<String>) -> Result<(Vec<u8>, Vec<String>)
     }
     let ser = serde_json::to_vec(&docs)?;
     debug!("decoded json: {}", String::from_utf8_lossy(&ser));
-    Ok((ser, args))
+    Ok(ser)
 }
 
 #[cfg(test)]
@@ -78,11 +88,11 @@ mod test {
     use super::*;
     #[tokio::test]
     async fn stdin() -> Result<()> {
-        let (data, _) = read_input_yaml(vec!["./test.yaml".into()]).await?;
-        let res = shellout(data.clone(), vec![".[2].metadata".into(), "-c".into()]).await?;
-        assert_eq!(res, "{\"name\":\"version\"}\n".to_string());
-        let res = shellout(data, vec![".[2].metadata".into(), "-y".into()]).await?;
-        assert_eq!(res, "name: version\n".to_string());
+        let data = read_input_yaml(&mut vec!["./test.yaml".into()]).await?;
+        //let res = shellout(data.clone(), &[".[2].metadata".into(), "-c".into()]).await?;
+        //assert_eq!(String::from_utf8(res)?, "{\"name\":\"version\"}\n".to_string());
+        let res = shellout(data, &[".[2].metadata".into(), "-y".into()]).await?;
+        assert_eq!(String::from_utf8(res)?, "name: version\n".to_string());
         Ok(())
     }
 }


### PR DESCRIPTION
Separates yq args from jq args by collecting all positionals into an `args.extra`.
This means no more filtering on `x != '-y'` or whatever other args we might implement from `yq` (that's not already implemented in `jq`).

This unfortunately does not allow an extra optional pathbuf arg at the end (at least not without `#[arg(last = true)]` which would force a breaking `--` requirement before the last positional), so we instead just collect all the args into extra that we do not explicitly need to mark and then check if the last extra arg is a file.

This also allowed splitting the cli in a slightly nicer way as impls on `Args`.