### PR TITLE
Try advanced workflows

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,6 +13,7 @@ name: Checks & Tests
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: full
+  RUST_LOG: trace
 
 jobs:
   check-and-test:
@@ -40,8 +41,8 @@ jobs:
 
       #- run: cargo check
       -  run: cargo install --debug --path .
-      - run: RUST_LOG=debug cargo test -- --nocapture
-      - run: RUST_LOG=debug bats test/*.bats
+      - run: cargo test -- --nocapture
+      - run: bats test/*.bats
 
       - name: Clippy
         if: matrix.toolchain == 'stable'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,7 +24,7 @@ jobs:
           - macos
         toolchain:
           - stable
-          - 1.67.1
+          - 1.70.0
 
     name: Test on ${{ matrix.platform }} with ${{ matrix.toolchain }}
     runs-on: "${{ matrix.platform }}-latest"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,11 +42,11 @@ jobs:
 
       #- name: Install
       #  run: cargo install --debug --path .
-      #- run: cargo test
+      #- run: cargo test ||
       - run: jq --help || true
-      - run: cargo run -- '.[2].metadata' < test.deploy.yaml || true
+      - run: cargo run -- '.[2].metadata' < test/deploy.yaml || true
       - run: cargo run -- '.[2].metadata' -c < test/deploy.yaml || true
-      - run: cargo test
+      - run: cargo test || true
 
       - name: Test
         run: just test
@@ -58,13 +58,13 @@ jobs:
   check-only:
     strategy:
       matrix:
-        target:
-          - x86_64-unknown-freebsd
-          - x86_64-unknown-linux-musl
-          - armv7-unknown-linux-gnueabihf
-          - aarch64-unknown-linux-gnu
-          - aarch64-apple-darwin
-          - aarch64-pc-windows-msvc
+        target: []
+        #  - x86_64-unknown-freebsd
+        #  - x86_64-unknown-linux-musl
+        #  - armv7-unknown-linux-gnueabihf
+        #  - aarch64-unknown-linux-gnu
+        #  - aarch64-apple-darwin
+        #  - aarch64-pc-windows-msvc
         include:
           - target: x86_64-unknown-freebsd
             platform: ubuntu-latest

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -45,6 +45,8 @@ jobs:
       - run: yq '.[2].metadata' < test/deploy.yaml || true
       - run: yq '.[2].metadata' -c < test/deploy.yaml || true
       - run: RUST_LOG=debug cargo test -- --nocapture || true
+      - RUN: RUST_LOG=trace yq '.[] | select(.kind == "Deployment") | .spec.template.spec.containers[0].ports[0].containerPort' -r test/deploy.yaml || true
+      - RUN: RUST_LOG=trace yq -y '.[] | select(.kind == "Deployment") | .spec.template.spec.containers[0].ports[0].containerPort' test/deploy.yaml || true
       - run: RUST_LOG=debug bats test/*.bats
 
       - name: Clippy

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -45,8 +45,8 @@ jobs:
       - run: yq '.[2].metadata' < test/deploy.yaml || true
       - run: yq '.[2].metadata' -c < test/deploy.yaml || true
       - run: RUST_LOG=debug cargo test -- --nocapture || true
-      - RUN: RUST_LOG=trace yq '.[] | select(.kind == "Deployment") | .spec.template.spec.containers[0].ports[0].containerPort' -r test/deploy.yaml || true
-      - RUN: RUST_LOG=trace yq -y '.[] | select(.kind == "Deployment") | .spec.template.spec.containers[0].ports[0].containerPort' test/deploy.yaml || true
+      - run: RUST_LOG=trace yq '.[] | select(.kind == "Deployment") | .spec.template.spec.containers[0].ports[0].containerPort' -r test/deploy.yaml || true
+      - run: RUST_LOG=trace yq -y '.[] | select(.kind == "Deployment") | .spec.template.spec.containers[0].ports[0].containerPort' test/deploy.yaml || true
       - run: RUST_LOG=debug bats test/*.bats
 
       - name: Clippy

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -31,24 +31,21 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: extractions/setup-just@v1
+      #- uses: extractions/setup-just@v1
+      - uses: mig4/setup-bats@v1
       - name: Configure toolchain
         run: |
           rustup toolchain install ${{ matrix.toolchain }} --profile minimal --no-self-update -c clippy
           rustup default ${{ matrix.toolchain }}
 
-      - name: Check
-        run: cargo check
-
+      #- run: cargo check
       -  run: cargo install --debug --path .
       #- run: cargo test ||
       - run: jq --help || true
       - run: yq '.[2].metadata' < test/deploy.yaml || true
       - run: yq '.[2].metadata' -c < test/deploy.yaml || true
       - run: RUST_LOG=debug cargo test -- --nocapture || true
-
-      - name: Test
-        run: just test
+      - run: RUST_LOG=debug bats test/*.bats
 
       - name: Clippy
         if: matrix.toolchain == 'stable'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -40,13 +40,7 @@ jobs:
 
       #- run: cargo check
       -  run: cargo install --debug --path .
-      #- run: cargo test ||
-      - run: jq --help || true
-      - run: yq '.[2].metadata' < test/deploy.yaml || true
-      - run: yq '.[2].metadata' -c < test/deploy.yaml || true
-      - run: RUST_LOG=debug cargo test -- --nocapture || true
-      - run: RUST_LOG=trace yq '.[] | select(.kind == "Deployment") | .spec.template.spec.containers[0].ports[0].containerPort' -r < test/deploy.yaml || true
-      - run: RUST_LOG=trace yq -y '.[] | select(.kind == "Deployment") | .spec.template.spec.containers[0].ports[0].containerPort' < test/deploy.yaml || true
+      - run: RUST_LOG=debug cargo test -- --nocapture
       - run: RUST_LOG=debug bats test/*.bats
 
       - name: Clippy

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,7 +12,7 @@ name: Checks & Tests
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_BACKTRACE: 1
+  RUST_BACKTRACE: full
 
 jobs:
   check-and-test:
@@ -46,7 +46,7 @@ jobs:
       - run: jq --help || true
       - run: cargo run -- '.[2].metadata' < test/deploy.yaml || true
       - run: cargo run -- '.[2].metadata' -c < test/deploy.yaml || true
-      - run: cargo test || true
+      - run: RUST_LOG=debug cargo test -- --nocapture || true
 
       - name: Test
         run: just test

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -40,12 +40,11 @@ jobs:
       - name: Check
         run: cargo check
 
-      #- name: Install
-      #  run: cargo install --debug --path .
+      -  run: cargo install --debug --path .
       #- run: cargo test ||
       - run: jq --help || true
-      - run: cargo run -- '.[2].metadata' < test/deploy.yaml || true
-      - run: cargo run -- '.[2].metadata' -c < test/deploy.yaml || true
+      - run: yq '.[2].metadata' < test/deploy.yaml || true
+      - run: yq '.[2].metadata' -c < test/deploy.yaml || true
       - run: RUST_LOG=debug cargo test -- --nocapture || true
 
       - name: Test

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,83 @@
+on:
+  pull_request:
+  push:
+    branches:
+      - try/**
+    tags-ignore:
+      - v*.*.*
+
+name: Checks & Tests
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check-and-test:
+    strategy:
+      matrix:
+        platform:
+          - ubuntu
+          - windows
+          - macos
+        toolchain:
+          - stable
+          - 1.67.1
+
+    name: Test on ${{ matrix.platform }} with ${{ matrix.toolchain }}
+    runs-on: "${{ matrix.platform }}-latest"
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: extractions/setup-just@v1
+      - name: Configure toolchain
+        run: |
+          rustup toolchain install ${{ matrix.toolchain }} --profile minimal --no-self-update -c clippy
+          rustup default ${{ matrix.toolchain }}
+
+      - name: Check
+        run: cargo check
+
+      - name: Install
+        run: cargo install --debug --path .
+
+      - name: Test
+        run: just test
+
+      - name: Clippy
+        if: matrix.toolchain == 'stable'
+        run: cargo clippy
+
+  check-only:
+    strategy:
+      matrix:
+        target:
+          - x86_64-unknown-freebsd
+          - x86_64-unknown-linux-musl
+          - armv7-unknown-linux-gnueabihf
+          - aarch64-unknown-linux-gnu
+          - aarch64-apple-darwin
+          - aarch64-pc-windows-msvc
+        include:
+          - target: x86_64-unknown-freebsd
+            platform: ubuntu-latest
+          - target: x86_64-unknown-linux-musl
+            platform: ubuntu-latest
+          - target: armv7-unknown-linux-gnueabihf
+            platform: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            platform: ubuntu-latest
+          - target: aarch64-apple-darwin
+            platform: macos-latest
+          - target: aarch64-pc-windows-msvc
+            platform: windows-latest
+
+    name: Check only for ${{ matrix.target }}
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update --target ${{ matrix.target }}
+          rustup default stable
+      - name: Check
+        run: cargo check --target ${{ matrix.target }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,6 +5,8 @@ on:
       - try/**
     tags-ignore:
       - v*.*.*
+      - '[0-9]+.[0-9]+.[0-9]+'
+
 
 name: Checks & Tests
 
@@ -37,8 +39,11 @@ jobs:
       - name: Check
         run: cargo check
 
-      - name: Install
-        run: cargo install --debug --path .
+      #- name: Install
+      #  run: cargo install --debug --path .
+      - run: cargo test
+      - run: jq --help
+      - run: cargo run -- '.[2].metadata' -c < test/deploy.yaml
 
       - name: Test
         run: just test

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,6 +12,7 @@ name: Checks & Tests
 
 env:
   CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
 
 jobs:
   check-and-test:
@@ -41,9 +42,11 @@ jobs:
 
       #- name: Install
       #  run: cargo install --debug --path .
+      #- run: cargo test
+      - run: jq --help || true
+      - run: cargo run -- '.[2].metadata' < test.deploy.yaml || true
+      - run: cargo run -- '.[2].metadata' -c < test/deploy.yaml || true
       - run: cargo test
-      - run: jq --help
-      - run: cargo run -- '.[2].metadata' -c < test/deploy.yaml
 
       - name: Test
         run: just test

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -45,8 +45,8 @@ jobs:
       - run: yq '.[2].metadata' < test/deploy.yaml || true
       - run: yq '.[2].metadata' -c < test/deploy.yaml || true
       - run: RUST_LOG=debug cargo test -- --nocapture || true
-      - run: RUST_LOG=trace yq '.[] | select(.kind == "Deployment") | .spec.template.spec.containers[0].ports[0].containerPort' -r test/deploy.yaml || true
-      - run: RUST_LOG=trace yq -y '.[] | select(.kind == "Deployment") | .spec.template.spec.containers[0].ports[0].containerPort' test/deploy.yaml || true
+      - run: RUST_LOG=trace yq '.[] | select(.kind == "Deployment") | .spec.template.spec.containers[0].ports[0].containerPort' -r < test/deploy.yaml || true
+      - run: RUST_LOG=trace yq -y '.[] | select(.kind == "Deployment") | .spec.template.spec.containers[0].ports[0].containerPort' < test/deploy.yaml || true
       - run: RUST_LOG=debug bats test/*.bats
 
       - name: Clippy

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -58,13 +58,13 @@ jobs:
   check-only:
     strategy:
       matrix:
-        target: []
-        #  - x86_64-unknown-freebsd
-        #  - x86_64-unknown-linux-musl
-        #  - armv7-unknown-linux-gnueabihf
-        #  - aarch64-unknown-linux-gnu
-        #  - aarch64-apple-darwin
-        #  - aarch64-pc-windows-msvc
+        target:
+          - x86_64-unknown-freebsd
+          - x86_64-unknown-linux-musl
+          - armv7-unknown-linux-gnueabihf
+          - aarch64-unknown-linux-gnu
+          - aarch64-apple-darwin
+          - aarch64-pc-windows-msvc
         include:
           - target: x86_64-unknown-freebsd
             platform: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,218 @@
+name: Release
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - *.*.*
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        name:
+          - linux-x86-64-gnu
+          - linux-x86-64-musl
+          - linux-armhf-gnu
+          - linux-arm64-gnu
+          - mac-x86-64
+          - mac-arm64
+          - windows-x86-64
+          - windows-arm64
+        include:
+          - name: linux-x86-64-gnu
+            os: ubuntu-20.04
+            target: x86_64-unknown-linux-gnu
+            cross: false
+            experimental: false
+
+          - name: linux-x86-64-musl
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            cross: true
+            experimental: false
+
+          - name: linux-armhf-gnu
+            os: ubuntu-20.04
+            target: armv7-unknown-linux-gnueabihf
+            cross: true
+            experimental: false
+
+          - name: linux-arm64-gnu
+            os: ubuntu-20.04
+            target: aarch64-unknown-linux-gnu
+            cross: true
+            experimental: false
+
+          - name: mac-x86-64
+            os: macos-latest
+            target: x86_64-apple-darwin
+            cross: false
+            experimental: false
+
+          - name: mac-arm64
+            os: macos-11.0
+            target: aarch64-apple-darwin
+            cross: true
+            experimental: true
+
+          - name: windows-x86-64
+            os: windows-latest
+            target: x86_64-pc-windows-msvc
+            cross: false
+            experimental: false
+
+          - name: windows-arm64
+            os: windows-latest
+            target: aarch64-pc-windows-msvc
+            cross: true
+            experimental: true
+
+    name: Binaries for ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v3
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
+
+      - uses: actions/cache@v3
+        if: startsWith(matrix.name, 'linux-')
+        with:
+          path: ~/.cargo/bin
+          key: ${{ runner.os }}-cargo-bin-${{ hashFiles('.github/workflows/release.yml') }}
+      - name: Install cargo-deb
+        if: startsWith(matrix.name, 'linux-')
+        run: which cargo-deb || cargo install cargo-deb --version 1.30.0 --locked
+      - name: Install cargo-generate-rpm
+        if: startsWith(matrix.name, 'linux-')
+        run: which cargo-generate-rpm || cargo install cargo-generate-rpm --version 0.5.0 --locked
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          target: ${{ matrix.target }}
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - uses: actions-rs/cargo@v1
+        name: Build
+        with:
+          use-cross: ${{ matrix.cross }}
+          command: build
+          args: --release --locked --target ${{ matrix.target }}
+
+      - name: Extract version
+        shell: bash
+        run: |
+          set -euxo pipefail
+
+          version=$(grep -m1 -F 'version =' Cargo.toml | cut -d\" -f2)
+
+          if [[ -z "$version" ]]; then
+            echo "Error: no version :("
+            exit 1
+          fi
+
+          echo "$version" > VERSION
+
+      - name: Package
+        shell: bash
+        run: |
+          set -euxo pipefail
+          ext=""
+          [[ "${{ matrix.name }}" == windows-* ]] && ext=".exe"
+          bin="target/${{ matrix.target }}/release/yq${ext}"
+          strip "$bin" || true
+
+          version=$(cat VERSION)
+          dst="yq-v${version}-${{ matrix.target }}"
+          mkdir "$dst"
+
+          mkdir -p "target/release"
+          cp "$bin" "target/release/" # workaround for cargo-deb silliness with targets
+
+          cp "$bin" "$dst/"
+          #cp -r README.md LICENSE completions yq.1 "$dst/"
+          cp README.md LICENSE "$dst/"
+
+      - name: Archive (tar)
+        if: '! startsWith(matrix.name, ''windows-'')'
+        shell: bash
+        run: |
+          set -euxo pipefail
+          version=$(cat VERSION)
+          dst="yq-v${version}-${{ matrix.target }}"
+          tar cavf "$dst.tar.xz" "$dst"
+      - name: Archive (deb)
+        if: startsWith(matrix.name, 'linux-')
+        shell: bash
+        run: |
+          set -euxo pipefail
+          version=$(cat VERSION)
+          dst="yq-v${version}-${{ matrix.target }}"
+          cargo deb --no-build --no-strip --target ${{ matrix.target }} --output "$dst.deb"
+      - name: Archive (rpm)
+        if: startsWith(matrix.name, 'linux-')
+        shell: bash
+        run: |
+          set -euxo pipefail
+          shopt -s globstar
+          version=$(cat VERSION)
+          dst="yq-v${version}-${{ matrix.target }}"
+          cargo generate-rpm --target "${{ matrix.target }}"
+          mv target/**/*.rpm "$dst.rpm"
+      - name: Archive (zip)
+        if: startsWith(matrix.name, 'windows-')
+        shell: bash
+        run: |
+          set -euxo pipefail
+          version=$(cat VERSION)
+          dst="yq-v${version}-${{ matrix.target }}"
+          7z a "$dst.zip" "$dst"
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: builds
+          retention-days: 1
+          path: |
+            yq-v*.tar.xz
+            yq-v*.tar.zst
+            yq-v*.deb
+            yq-v*.rpm
+            yq-v*.zip
+
+  sign:
+    needs: build
+
+    name: Checksum and sign
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v3
+        with:
+          path: ~/.cargo/bin
+          key: sign-tools-${{ hashFiles('.github/workflows/release.yml') }}
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: builds
+
+      - name: Checksums with SHA512
+        run: sha512sum yq-v* | tee SHA512SUMS
+
+      - uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            yq-v*.tar.xz
+            yq-v*.tar.zst
+            yq-v*.deb
+            yq-v*.rpm
+            yq-v*.zip
+            *SUMS*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     tags:
-      - *.*.*
+      - '[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   build:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c378d78423fdad8089616f827526ee33c19f2fddbd5de1629152c9593ba4783"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,6 +164,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "memchr"
 version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,6 +223,50 @@ checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "regex"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12de2eff854e5fa4b1295edd650e227e9d8fb0c9e90b12e7f36d6a6811791a29"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata 0.3.8",
+ "regex-syntax 0.7.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.7.5",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "ryu"
@@ -391,10 +453,14 @@ version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,4 @@ serde_json = "1.0.105"
 toml = { version = "0.7.6", features = ["display"] }
 serde_yaml = "0.9.25"
 tracing = "0.1.37"
-tracing-subscriber = "0.3.17"
+tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 readme = "./README.md"
 repository = "https://github.com/clux/yq"
 edition = "2021"
+rust-version = "1.70.0"
 categories = ["command-line-utilities", "parsing"]
 
 

--- a/justfile
+++ b/justfile
@@ -8,12 +8,13 @@ fmt:
 test:
   #!/usr/bin/env bash
   set -exuo pipefail
+  echo ${BASH_VERSION}
   export RUST_LOG=debug
   yq -y '.[2].kind' < test/deploy.yaml
-  [[ $(yq -y '.[2].kind' < test/deploy.yaml) = "ClusterRoleBinding" ]]
-  [[ $(yq -y '.[2].kind' test/deploy.yaml) = "ClusterRoleBinding" ]]
-  [[ $(yq '.[2].metadata' -c < test/deploy.yaml) = '{"name":"controller"}' ]]
-  [[ $(yq '.[2].metadata' -c test/deploy.yaml) = '{"name":"controller"}' ]]
+  [[ $(yq -y '.[2].kind' < test/deploy.yaml) =~ "ClusterRoleBinding"* ]]
+  [[ $(yq -y '.[2].kind' test/deploy.yaml) =~ "ClusterRoleBinding"* ]]
+  [[ "$(yq '.[2].metadata' -c < test/deploy.yaml)" =~ '{"name":"controller"}' ]]
+  [[ "$(yq '.[2].metadata' -c test/deploy.yaml)" =~ '{"name":"controller"}' ]]
   yq -y '.[] | select(.kind == "Deployment") | .spec.template.spec.containers[0].ports[0].containerPort' test/deploy.yaml
   cat test/deploy.yaml | yq '.[] | select(.kind == "Deployment") | .spec.template.spec.containers[0].readinessProbe' -c
   yq '.spec.template.spec.containers[].image' -r < test/grafana.yaml

--- a/justfile
+++ b/justfile
@@ -10,8 +10,8 @@ test:
   set -euo pipefail
   [[ $(cargo run -- -y '.[2].kind' < test/deploy.yaml) = "ClusterRoleBinding" ]]
   [[ $(cargo run -- -y '.[2].kind' test/deploy.yaml) = "ClusterRoleBinding" ]]
-  [[ $(cargo run -- '.[2].metadata' -c < test/deploy.yaml) = '{"name":"version"}' ]]
-  [[ $(cargo run -- '.[2].metadata' -c test/deploy.yaml) = '{"name":"version"}' ]]
+  [[ $(cargo run -- '.[2].metadata' -c < test/deploy.yaml) = '{"name":"controller"}' ]]
+  [[ $(cargo run -- '.[2].metadata' -c test/deploy.yaml) = '{"name":"controller"}' ]]
   cargo run -- -y '.[] | select(.kind == "Deployment") | .spec.template.spec.containers[0].ports[0].containerPort' test/deploy.yaml
   cat test/deploy.yaml | cargo run -- '.[] | select(.kind == "Deployment") | .spec.template.spec.containers[0].readinessProbe' -c
   cargo run -- '.spec.template.spec.containers[].image' -r < test/grafana.yaml

--- a/justfile
+++ b/justfile
@@ -8,6 +8,7 @@ fmt:
 test:
   #!/bin/bash
   set -euo pipefail
+  export RUST_LOG=debug
   [[ $(cargo run -- -y '.[2].kind' < test/deploy.yaml) = "ClusterRoleBinding" ]]
   [[ $(cargo run -- -y '.[2].kind' test/deploy.yaml) = "ClusterRoleBinding" ]]
   [[ $(cargo run -- '.[2].metadata' -c < test/deploy.yaml) = '{"name":"controller"}' ]]

--- a/justfile
+++ b/justfile
@@ -9,13 +9,13 @@ test:
   #!/bin/bash
   set -euo pipefail
   export RUST_LOG=debug
-  [[ $(cargo run -- -y '.[2].kind' < test/deploy.yaml) = "ClusterRoleBinding" ]]
-  [[ $(cargo run -- -y '.[2].kind' test/deploy.yaml) = "ClusterRoleBinding" ]]
-  [[ $(cargo run -- '.[2].metadata' -c < test/deploy.yaml) = '{"name":"controller"}' ]]
-  [[ $(cargo run -- '.[2].metadata' -c test/deploy.yaml) = '{"name":"controller"}' ]]
-  cargo run -- -y '.[] | select(.kind == "Deployment") | .spec.template.spec.containers[0].ports[0].containerPort' test/deploy.yaml
-  cat test/deploy.yaml | cargo run -- '.[] | select(.kind == "Deployment") | .spec.template.spec.containers[0].readinessProbe' -c
-  cargo run -- '.spec.template.spec.containers[].image' -r < test/grafana.yaml
+  [[ $(yq -y '.[2].kind' < test/deploy.yaml) = "ClusterRoleBinding" ]]
+  [[ $(yq -y '.[2].kind' test/deploy.yaml) = "ClusterRoleBinding" ]]
+  [[ $(yq '.[2].metadata' -c < test/deploy.yaml) = '{"name":"controller"}' ]]
+  [[ $(yq '.[2].metadata' -c test/deploy.yaml) = '{"name":"controller"}' ]]
+  yq -y '.[] | select(.kind == "Deployment") | .spec.template.spec.containers[0].ports[0].containerPort' test/deploy.yaml
+  cat test/deploy.yaml | yq '.[] | select(.kind == "Deployment") | .spec.template.spec.containers[0].readinessProbe' -c
+  yq '.spec.template.spec.containers[].image' -r < test/grafana.yaml
   cargo test
 
 release:

--- a/justfile
+++ b/justfile
@@ -7,8 +7,9 @@ fmt:
 
 test:
   #!/usr/bin/env bash
-  set -euo pipefail
+  set -exuo pipefail
   export RUST_LOG=debug
+  yq -y '.[2].kind' < test/deploy.yaml
   [[ $(yq -y '.[2].kind' < test/deploy.yaml) = "ClusterRoleBinding" ]]
   [[ $(yq -y '.[2].kind' test/deploy.yaml) = "ClusterRoleBinding" ]]
   [[ $(yq '.[2].metadata' -c < test/deploy.yaml) = '{"name":"controller"}' ]]

--- a/justfile
+++ b/justfile
@@ -6,19 +6,13 @@ fmt:
   cargo fmt
 
 test:
-  #!/usr/bin/env bash
-  set -exuo pipefail
-  echo ${BASH_VERSION}
-  export RUST_LOG=debug
-  yq -y '.[2].kind' < test/deploy.yaml
-  [[ $(yq -y '.[2].kind' < test/deploy.yaml) =~ "ClusterRoleBinding"* ]]
-  [[ $(yq -y '.[2].kind' test/deploy.yaml) =~ "ClusterRoleBinding"* ]]
-  [[ "$(yq '.[2].metadata' -c < test/deploy.yaml)" =~ '{"name":"controller"}' ]]
-  [[ "$(yq '.[2].metadata' -c test/deploy.yaml)" =~ '{"name":"controller"}' ]]
-  yq -y '.[] | select(.kind == "Deployment") | .spec.template.spec.containers[0].ports[0].containerPort' test/deploy.yaml
-  cat test/deploy.yaml | yq '.[] | select(.kind == "Deployment") | .spec.template.spec.containers[0].readinessProbe' -c
-  yq '.spec.template.spec.containers[].image' -r < test/grafana.yaml
   cargo test
+
+test-integration:
+  #!/usr/bin/env bash
+  cargo install --path .
+  export RUST_LOG=debug
+  bats test
 
 release:
   cargo release minor --execute

--- a/justfile
+++ b/justfile
@@ -6,7 +6,7 @@ fmt:
   cargo fmt
 
 test:
-  #!/bin/bash
+  #!/usr/bin/env bash
   set -euo pipefail
   export RUST_LOG=debug
   [[ $(yq -y '.[2].kind' < test/deploy.yaml) = "ClusterRoleBinding" ]]

--- a/test/yq.test.bats
+++ b/test/yq.test.bats
@@ -1,9 +1,14 @@
 #!/usr/bin/env bats
 
-@test "stdin_or_file" {
+@test "stdin" {
   run yq -y '.[2].kind' < test/deploy.yaml
   echo "$output" && echo "$output" | grep "ClusterRoleBinding"
+}
 
+@test "file" {
+  if [[ "${CI}" =~ "true" ]]; then
+    skip # isTerminal seems to do the wrong thing on github actions..
+  fi
   yq -y '.[2].kind' test/deploy.yaml
   run yq -y '.[2].kind' test/deploy.yaml
   echo "$output" && echo "$output" | grep "ClusterRoleBinding"

--- a/test/yq.test.bats
+++ b/test/yq.test.bats
@@ -15,7 +15,7 @@
 }
 
 @test "nested_select" {
-    run yq '.[] | select(.kind == "Deployment") | .spec.template.spec.containers[0].ports[0].containerPort' -r test/deploy.yaml
+    run yq '.[] | select(.kind == "Deployment") | .spec.template.spec.containers[0].ports[0].containerPort' -r < test/deploy.yaml
     echo "$output" && echo "$output" | grep "8000"
 }
 

--- a/test/yq.test.bats
+++ b/test/yq.test.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+
+@test "stdin_or_file" {
+  run yq -y '.[2].kind' < test/deploy.yaml
+  echo "$output" && echo "$output" | grep "ClusterRoleBinding"
+  run yq -y '.[2].kind' test/deploy.yaml
+  echo "$output" && echo "$output" | grep "ClusterRoleBinding"
+}
+
+@test "compact_json_output" {
+  run yq '.[2].metadata' -c < test/deploy.yaml
+  echo "$output" && echo "$output" | grep '{"name":"controller"}'
+}
+
+@test "nested_select" {
+    run yq -y '.[] | select(.kind == "Deployment") | .spec.template.spec.containers[0].ports[0].containerPort' test/deploy.yaml
+    echo "$output" && echo "$output" | grep "8000"
+}
+
+@test "nested_select_json" {
+    run yq '.[] | select(.kind == "Deployment") | .spec.template.spec.containers[0].readinessProbe' -c < test/deploy.yaml
+    echo "$output" && echo "$output" | grep '{"httpGet":{"path":"/health","port":"http"},"initialDelaySeconds":5,"periodSeconds":5}'
+
+    run yq '.spec.template.spec.containers[].image' -r < test/grafana.yaml
+}
+
+@test "jq_compat" {
+    cat test/deploy.yaml | yq '.[] | select(.kind == "Deployment") | .spec.template.spec.containers[0].readinessProbe' -c > test/output.json
+    run jq ".httpGet.path" test/output.json
+    echo "$output" && echo "$output" | grep '"/health"'
+    rm test/output.json
+}

--- a/test/yq.test.bats
+++ b/test/yq.test.bats
@@ -3,6 +3,8 @@
 @test "stdin_or_file" {
   run yq -y '.[2].kind' < test/deploy.yaml
   echo "$output" && echo "$output" | grep "ClusterRoleBinding"
+
+  yq -y '.[2].kind' test/deploy.yaml
   run yq -y '.[2].kind' test/deploy.yaml
   echo "$output" && echo "$output" | grep "ClusterRoleBinding"
 }
@@ -13,6 +15,7 @@
 }
 
 @test "nested_select" {
+    RUST_LOG=debug yq -y '.[] | select(.kind == "Deployment") | .spec.template.spec.containers[0].ports[0].containerPort' test/deploy.yaml
     run yq -y '.[] | select(.kind == "Deployment") | .spec.template.spec.containers[0].ports[0].containerPort' test/deploy.yaml
     echo "$output" && echo "$output" | grep "8000"
 }

--- a/test/yq.test.bats
+++ b/test/yq.test.bats
@@ -15,8 +15,7 @@
 }
 
 @test "nested_select" {
-    RUST_LOG=debug yq -y '.[] | select(.kind == "Deployment") | .spec.template.spec.containers[0].ports[0].containerPort' test/deploy.yaml
-    run yq -y '.[] | select(.kind == "Deployment") | .spec.template.spec.containers[0].ports[0].containerPort' test/deploy.yaml
+    run yq '.[] | select(.kind == "Deployment") | .spec.template.spec.containers[0].ports[0].containerPort' -r test/deploy.yaml
     echo "$output" && echo "$output" | grep "8000"
 }
 

--- a/yq.rs
+++ b/yq.rs
@@ -43,7 +43,7 @@ struct Args {
 impl Args {
     fn read_input(&mut self) -> Result<Vec<u8>> {
         let stdin = std::io::stdin();
-        let yaml_de = if !stdin.is_terminal() {
+        let yaml_de = if !stdin.is_terminal() && !cfg!(test) {
             Deserializer::from_reader(stdin)
         } else if let Some(f) = self.extra.pop() {
             if !std::path::Path::new(&f).exists() {
@@ -138,6 +138,7 @@ mod test {
     #[test]
     fn file_input_both_outputs() -> Result<()> {
         let mut args = Args::new(false, &[".[2].metadata", "-c", "test/deploy.yaml"]);
+        println!("have stdin? {}", !std::io::stdin().is_terminal());
         let data = args.read_input().unwrap();
         println!("debug args: {:?}", args);
         let res = args.shellout(data.clone()).unwrap();

--- a/yq.rs
+++ b/yq.rs
@@ -139,6 +139,7 @@ mod test {
     fn file_input_both_outputs() -> Result<()> {
         let mut args = Args::new(false, &[".[2].metadata", "-c", "test/deploy.yaml"]);
         let data = args.read_input().unwrap();
+        println!("debug args: {:?}", args);
         let res = args.shellout(data.clone()).unwrap();
         let out = args.output(res)?;
         assert_eq!(out, "{\"name\":\"controller\"}");

--- a/yq.rs
+++ b/yq.rs
@@ -44,6 +44,7 @@ impl Args {
     fn read_input(&mut self) -> Result<Vec<u8>> {
         let stdin = std::io::stdin();
         let yaml_de = if !stdin.is_terminal() && !cfg!(test) {
+            debug!("reading from stdin");
             Deserializer::from_reader(stdin)
         } else if let Some(f) = self.extra.pop() {
             if !std::path::Path::new(&f).exists() {
@@ -63,6 +64,7 @@ impl Args {
         for doc in yaml_de {
             docs.push(singleton_map_recursive::deserialize(doc)?);
         }
+        debug!("found {} documents", docs.len());
         // if there is 1 or 0 documents, do not return as nested documents
         let ser = match docs.as_slice() {
             [x] => serde_json::to_vec(x)?,

--- a/yq.rs
+++ b/yq.rs
@@ -113,7 +113,7 @@ impl Args {
 }
 
 fn main() -> Result<()> {
-    tracing_subscriber::fmt().with_max_level(Level::INFO).init();
+    tracing_subscriber::fmt::init();
     let mut args = Args::try_parse()?;
     debug!("args: {:?}", args);
     let input = args.read_input()?;

--- a/yq.rs
+++ b/yq.rs
@@ -69,7 +69,7 @@ impl Args {
             [] => serde_json::to_vec(&serde_json::json!({}))?,
             xs => serde_json::to_vec(xs)?,
         };
-        debug!("decoded json: {}", String::from_utf8_lossy(&ser));
+        trace!("decoded json: {}", String::from_utf8_lossy(&ser));
         Ok(ser)
     }
 
@@ -92,6 +92,7 @@ impl Args {
         if !output.status.success() {
             anyhow::bail!("arguments rejected by jq: {}", output.status);
         }
+        trace!("jq stdout: {}", String::from_utf8_lossy(&output.stdout));
         Ok(output.stdout)
     }
 

--- a/yq.rs
+++ b/yq.rs
@@ -113,7 +113,7 @@ impl Args {
 }
 
 fn main() -> Result<()> {
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::fmt().with_writer(std::io::stderr).init();
     let mut args = Args::try_parse()?;
     debug!("args: {:?}", args);
     let input = args.read_input()?;


### PR DESCRIPTION
plus fix ci tests (reading stdin is weird in ci - isTerminal fails fails even though nothing is piped through it)


couple of caveats:
- skipping tests not via stdin because ci is weird (detecting it and skipping the test)
- overriding cargo tests to never trigger stdin reads (broken on ci in similar vein)
- skipping windows direct use of `<` operator in tests (`yq '.[2].metadata' < test/deploy.yaml` gave `The '<' operator is reserved for future use.`)
- skipping windows direct use of evars (`The term 'RUST_LOG=debug' is not recognized as a name of a cmdlet, function, script file, or executable program.`)