### PR TITLE
switch over from serde-yaml to serde-saphyr

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,7 +25,7 @@ jobs:
           - macos
         toolchain:
           - stable
-          - 1.85.0
+          - 1.88.0
 
     name: Test on ${{ matrix.platform }} with ${{ matrix.toolchain }}
     runs-on: "${{ matrix.platform }}-latest"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,9 +398,8 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "saphyr-parser-bw"
-version = "0.0.608"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d55ae5ea09894b6d5382621db78f586df37ef18ab581bf32c754e75076b124b1"
+version = "0.0.609"
+source = "git+https://github.com/bourumir-wyngs/saphyr?branch=dev%2Fsaphyr-parser#6cc570b7a6a1690160732fff2d0b584a79c67215"
 dependencies = [
  "arraydeque",
  "smallvec",
@@ -419,9 +418,8 @@ dependencies = [
 
 [[package]]
 name = "serde-saphyr"
-version = "0.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfcaa44cda9e21eaf5fefc86175d544a359d4de9bcd1f3a90be7bbf77dfc3492"
+version = "0.0.21"
+source = "git+https://github.com/bourumir-wyngs/serde-saphyr.git?rev=3aedc10b8202370d926ed456f8476563d1a70966#3aedc10b8202370d926ed456f8476563d1a70966"
 dependencies = [
  "ahash",
  "annotate-snippets",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,36 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "annotate-snippets"
+version = "0.12.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c86cd1c51b95d71dde52bca69ed225008f6ff4c8cc825b08042aa1ef823e1980"
+dependencies = [
+ "anstyle",
+ "memchr",
+ "unicode-width",
 ]
 
 [[package]]
@@ -68,6 +92,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,10 +168,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "hashbrown"
@@ -160,10 +240,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "js-sys"
+version = "0.3.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e709f3e3d22866f9c25b3aff01af289b18422cc8b4262fb19103ee80fe513d"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "libc"
+version = "0.2.182"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "log"
@@ -177,8 +273,8 @@ version = "0.15.0"
 dependencies = [
  "anyhow",
  "clap",
+ "serde-saphyr",
  "serde_json",
- "serde_yaml",
  "toml",
  "tracing",
  "tracing-subscriber",
@@ -200,12 +296,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -245,6 +356,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,10 +391,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
-name = "ryu"
-version = "1.0.20"
+name = "rustversion"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "saphyr-parser-bw"
+version = "0.0.608"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55ae5ea09894b6d5382621db78f586df37ef18ab581bf32c754e75076b124b1"
+dependencies = [
+ "arraydeque",
+ "smallvec",
+ "thiserror",
+]
 
 [[package]]
 name = "serde"
@@ -274,6 +414,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde-saphyr"
+version = "0.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfcaa44cda9e21eaf5fefc86175d544a359d4de9bcd1f3a90be7bbf77dfc3492"
+dependencies = [
+ "ahash",
+ "annotate-snippets",
+ "base64",
+ "encoding_rs_io",
+ "getrandom",
+ "nohash-hasher",
+ "num-traits",
+ "regex",
+ "saphyr-parser-bw",
+ "serde",
+ "smallvec",
+ "zmij",
 ]
 
 [[package]]
@@ -320,19 +481,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,6 +510,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -480,10 +648,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
+name = "unicode-width"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "utf8parse"
@@ -496,6 +664,66 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1adf1535672f5b7824f817792b1afd731d7e843d2d04ec8f27e8cb51edd8ac"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e638317c08b21663aed4d2b9a2091450548954695ff4efa75bff5fa546b3b1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c64760850114d03d5f65457e96fc988f11f01d38fbaa51b254e4ab5809102af"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60eecd4fe26177cfa3339eb00b4a36445889ba3ad37080c2429879718e20ca41"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "windows-link"
@@ -591,6 +819,32 @@ name = "winnow"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 readme = "./README.md"
 repository = "https://github.com/clux/lq"
 edition = "2024"
-rust-version = "1.85.0"
+rust-version = "1.88.0"
 categories = ["command-line-utilities", "parsing"]
 keywords = ["yaml", "json", "toml", "query"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,9 @@ anyhow = "1.0.100"
 clap = { version = "4.5.56", features = ["cargo", "derive"] }
 serde_json = { version = "1.0.149", features = ["preserve_order"] }
 toml = { version = "0.9.11", features = ["display", "preserve_order"] }
-serde_yaml = "0.9.34"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
+serde-saphyr = "0.0.20"
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,11 @@ serde_json = { version = "1.0.149", features = ["preserve_order"] }
 toml = { version = "0.9.11", features = ["display", "preserve_order"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
-serde-saphyr = "0.0.20"
+# serde-saphyr = "0.0.20"
+
+[dependencies.serde-saphyr]
+git = "https://github.com/bourumir-wyngs/serde-saphyr.git"
+rev = "3aedc10b8202370d926ed456f8476563d1a70966"
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -50,8 +50,7 @@ cargo binstall lq
 - Shells out to `jq` (not standalone - [for now](https://github.com/clux/lq/issues/64))
 - Expands [YAML tags](https://yaml.org/spec/1.2-old/spec.html#id2764295) as part of deserialization - so tags are [not preserved](https://github.com/clux/lq/issues/12) in the output
 - Does not preserve indentation (was unsupported in [serde_yaml](https://github.com/dtolnay/serde-yaml/issues/337), but could be done now with saphyr)
-- If duplicate keys is found in YAML then the last key wins (see [#86](https://github.com/clux/lq/issues/86))
-- Halts on [duplicate keys](https://github.com/clux/lq/issues/14) in the input document (could be changed now with saphyr)
+- Halts on [DuplicateKeys](https://docs.rs/serde-saphyr/latest/serde_saphyr/options/enum.DuplicateKeyPolicy.html) in the input document (but [we could allow overriding this](https://github.com/clux/lq/issues/86))
 - Formats require a [serde implementation](https://serde.rs/#data-formats).
 - Limited format support. No XML/CSV/RON support (or other more exotic formats). [KDL wanted](https://github.com/clux/lq/issues/56).
 

--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ cargo binstall lq
 ### Limitations
 
 - Shells out to `jq` (not standalone - [for now](https://github.com/clux/lq/issues/64))
-- Expands [YAML tags](https://yaml.org/spec/1.2-old/spec.html#id2764295) (input is [singleton mapped](https://docs.rs/serde_yaml/latest/serde_yaml/with/singleton_map/index.html) -> [recursively](https://docs.rs/serde_yaml/latest/serde_yaml/with/singleton_map_recursive/index.html), then [merged](https://docs.rs/serde_yaml/latest/serde_yaml/value/enum.Value.html#method.apply_merge)) - so tags are [not preserved](https://github.com/clux/lq/issues/12) in the output
-- Does not preserve indentation (unsupported in [serde_yaml](https://github.com/dtolnay/serde-yaml/issues/337))
-- Halts on [duplicate keys](https://github.com/clux/lq/issues/14) in the input document
+- Expands [YAML tags](https://yaml.org/spec/1.2-old/spec.html#id2764295) as part of deserialization - so tags are [not preserved](https://github.com/clux/lq/issues/12) in the output
+- Does not preserve indentation (was unsupported in [serde_yaml](https://github.com/dtolnay/serde-yaml/issues/337), but could be done now with saphyr)
+- If duplicate keys is found in YAML then the last key wins (see [#86](https://github.com/clux/lq/issues/86))
+- Halts on [duplicate keys](https://github.com/clux/lq/issues/14) in the input document (could be changed now with saphyr)
 - Formats require a [serde implementation](https://serde.rs/#data-formats).
 - Limited format support. No XML/CSV/RON support (or other more exotic formats). [KDL wanted](https://github.com/clux/lq/issues/56).
 

--- a/lq.rs
+++ b/lq.rs
@@ -346,26 +346,14 @@ impl Args {
                     .collect::<Vec<_>>();
                 let options = serde_saphyr::ser_options! {
                     indent_step: 2,
+                    compact_list_indent: true,
                     tagged_enums: true,
                 };
                 // handle multidoc from jq output (e.g. '.[].name' type queries on multidoc input)
-                // let output = serde_saphyr::to_string_multiple(docs.as_slice())?;
                 let output = match docs.as_slice() {
                     [x] => serde_saphyr::to_string_with_options(&x, options)?,
                     [] => serde_saphyr::to_string_with_options(&serde_json::json!({}), options)?,
-                    ys => {
-                        // to_string_multiple does not have an options variant atm
-                        let mut out = String::new();
-                        let mut first = true;
-                        for y in ys {
-                            if !first {
-                                out.push_str("---\n");
-                            }
-                            first = false;
-                            out.push_str(&serde_saphyr::to_string_with_options(&y, options)?);
-                        }
-                        out
-                    }
+                    ys => serde_saphyr::to_string_multiple_with_options(ys, options)?,
                 };
                 Ok(output.trim_end().to_string())
             }

--- a/lq.rs
+++ b/lq.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use clap::{Parser, ValueEnum};
-use serde_yaml::{self, Deserializer, with::singleton_map_recursive};
+use serde_saphyr;
 use std::io::{BufReader, IsTerminal, Read, Write, stderr, stdin};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
@@ -162,34 +162,33 @@ impl Args {
     }
 
     fn read_yaml_docs(&mut self) -> Result<Vec<serde_json::Value>> {
-        let yaml_de = if let Some(f) = &self.file {
+        let data = if let Some(f) = &self.file {
             if !std::path::Path::new(&f).exists() {
                 Self::try_parse_from(["cmd", "-h"])?;
                 std::process::exit(2);
             }
             let file = std::fs::File::open(f)?;
-            // NB: can do everything async (via tokio + tokio_util) except this:
-            // serde only has a sync reader interface, so may as well do all sync.
-            Deserializer::from_reader(BufReader::new(file))
+            let mut buf_reader = BufReader::new(file);
+            let mut data = String::new();
+            buf_reader.read_to_string(&mut data)?;
+            data
         } else if !stdin().is_terminal() && !cfg!(test) {
             debug!("reading from stdin");
-            Deserializer::from_reader(stdin())
+            // use std::io::{stdin, Read};
+            let mut buf = Vec::new();
+            stdin().read_to_end(&mut buf)?;
+            let input = String::from_utf8(buf)?;
+            input
+            // serde_saphyr::from_reader(stdin())?
         } else {
             // NB: awkwardly prints a stack trace when people set RUST_STACKTRACE
             Self::try_parse_from(["cmd", "-h"])?;
             std::process::exit(2);
         };
-
-        let mut docs: Vec<serde_json::Value> = vec![];
-        for doc in yaml_de {
-            let json_value: serde_json::Value = {
-                let mut yaml_doc: serde_yaml::Value = singleton_map_recursive::deserialize(doc)?;
-                yaml_doc.apply_merge()?;
-                let yaml_ser = serde_yaml::to_string(&yaml_doc)?;
-                serde_yaml::from_str(&yaml_ser)?
-            };
-            docs.push(json_value);
-        }
+        let options = serde_saphyr::options! {
+            duplicate_keys: serde_saphyr::DuplicateKeyPolicy::FirstWins,
+        };
+        let docs = serde_saphyr::from_multiple_with_options(&data, options)?;
         debug!("found {} documents", docs.len());
         Ok(docs)
     }
@@ -345,10 +344,11 @@ impl Args {
                     .flatten()
                     .collect::<Vec<_>>();
                 debug!("parsed {} documents", docs.len());
+                // TODO: tagged_enums: true to convert
                 let output = match docs.as_slice() {
-                    [x] => serde_yaml::to_string(&x)?,
-                    [] => serde_yaml::to_string(&serde_json::json!({}))?,
-                    xs => serde_yaml::to_string(&xs)?,
+                    [x] => serde_saphyr::to_string(&x)?,
+                    [] => serde_saphyr::to_string(&serde_json::json!({}))?,
+                    xs => serde_saphyr::to_string(&xs)?,
                 };
                 Ok(output.trim_end().to_string())
             }
@@ -373,7 +373,7 @@ impl Args {
             let str_doc: String = match self.output {
                 // We even need jq output to be valid json in this case to allow multidoc to be matched up
                 Output::Jq => serde_json::to_string_pretty(&x)?,
-                Output::Yaml => serde_yaml::to_string(&x)?,
+                Output::Yaml => serde_saphyr::to_string(&x)?,
                 Output::Toml => toml::to_string(&x)?,
             };
             res.push(str_doc.trim_end().to_string());

--- a/lq.rs
+++ b/lq.rs
@@ -162,6 +162,9 @@ impl Args {
     }
 
     fn read_yaml_docs(&mut self) -> Result<Vec<serde_json::Value>> {
+        let options = serde_saphyr::options! {
+            duplicate_keys: serde_saphyr::DuplicateKeyPolicy::FirstWins,
+        };
         let data = if let Some(f) = &self.file {
             if !std::path::Path::new(&f).exists() {
                 Self::try_parse_from(["cmd", "-h"])?;
@@ -172,21 +175,19 @@ impl Args {
             let mut data = String::new();
             buf_reader.read_to_string(&mut data)?;
             data
+            // serde_saphyr::from_reader_with_options(BufReader::new(file), options)
         } else if !stdin().is_terminal() && !cfg!(test) {
             debug!("reading from stdin");
-            // use std::io::{stdin, Read};
+            use std::io::{Read, stdin};
             let mut buf = Vec::new();
             stdin().read_to_end(&mut buf)?;
             let input = String::from_utf8(buf)?;
             input
-            // serde_saphyr::from_reader(stdin())?
+            // serde_saphyr::from_reader_with_options(stdin(), options)
         } else {
             // NB: awkwardly prints a stack trace when people set RUST_STACKTRACE
             Self::try_parse_from(["cmd", "-h"])?;
             std::process::exit(2);
-        };
-        let options = serde_saphyr::options! {
-            duplicate_keys: serde_saphyr::DuplicateKeyPolicy::FirstWins,
         };
         let docs: Vec<serde_json::Value> = serde_saphyr::from_multiple_with_options(&data, options)?;
         debug!("found {} documents", docs.len());

--- a/lq.rs
+++ b/lq.rs
@@ -163,7 +163,9 @@ impl Args {
 
     fn read_yaml_docs(&mut self) -> Result<Vec<serde_json::Value>> {
         let options = serde_saphyr::options! {
-            duplicate_keys: serde_saphyr::DuplicateKeyPolicy::FirstWins,
+            // allow duplicate keys in the awkward Kubernetes style by default
+            // TODO: allow passing a strict flag?
+            duplicate_keys: serde_saphyr::DuplicateKeyPolicy::LastWins,
         };
         let data = if let Some(f) = &self.file {
             if !std::path::Path::new(&f).exists() {

--- a/lq.rs
+++ b/lq.rs
@@ -163,9 +163,10 @@ impl Args {
 
     fn read_yaml_docs(&mut self) -> Result<Vec<serde_json::Value>> {
         let options = serde_saphyr::options! {
-            // allow duplicate keys in the awkward Kubernetes style by default
-            // TODO: allow passing a strict flag?
-            duplicate_keys: serde_saphyr::DuplicateKeyPolicy::LastWins,
+            duplicate_keys: serde_saphyr::DuplicateKeyPolicy::Error, // want strict by default
+            // TODO: allow duplicate keys in the awkward Kubernetes style under a flag?
+            // https://github.com/clux/lq/issues/86
+            // duplicate_keys: serde_saphyr::DuplicateKeyPolicy::LastWins,
         };
         let data = if let Some(f) = &self.file {
             if !std::path::Path::new(&f).exists() {

--- a/lq.rs
+++ b/lq.rs
@@ -188,7 +188,7 @@ impl Args {
         let options = serde_saphyr::options! {
             duplicate_keys: serde_saphyr::DuplicateKeyPolicy::FirstWins,
         };
-        let docs = serde_saphyr::from_multiple_with_options(&data, options)?;
+        let docs: Vec<serde_json::Value> = serde_saphyr::from_multiple_with_options(&data, options)?;
         debug!("found {} documents", docs.len());
         Ok(docs)
     }
@@ -196,6 +196,7 @@ impl Args {
     fn read_yaml(&mut self) -> Result<Vec<u8>> {
         // yaml is multidoc parsed by default, so flatten when <2 docs to conform to jq interface
         let docs = self.read_yaml_docs()?;
+        trace!("got {} yaml docs", docs.len());
         // if there is 1 or 0 documents, do not return as nested documents
         let ser = match docs.as_slice() {
             [x] => serde_json::to_vec(x)?,
@@ -338,17 +339,32 @@ impl Args {
             }
             // Other outputs are speculatively parsed as the requested formats
             Output::Yaml => {
-                // handle multidoc from jq output (e.g. '.[].name' type queries on multidoc input)
                 let docs = serde_json::Deserializer::from_slice(&stdout)
                     .into_iter::<serde_json::Value>()
                     .flatten()
                     .collect::<Vec<_>>();
-                debug!("parsed {} documents", docs.len());
-                // TODO: tagged_enums: true to convert
+                let options = serde_saphyr::ser_options! {
+                    indent_step: 2,
+                    tagged_enums: true,
+                };
+                // handle multidoc from jq output (e.g. '.[].name' type queries on multidoc input)
+                // let output = serde_saphyr::to_string_multiple(docs.as_slice())?;
                 let output = match docs.as_slice() {
-                    [x] => serde_saphyr::to_string(&x)?,
-                    [] => serde_saphyr::to_string(&serde_json::json!({}))?,
-                    xs => serde_saphyr::to_string(&xs)?,
+                    [x] => serde_saphyr::to_string_with_options(&x, options)?,
+                    [] => serde_saphyr::to_string_with_options(&serde_json::json!({}), options)?,
+                    ys => {
+                        // to_string_multiple does not have an options variant atm
+                        let mut out = String::new();
+                        let mut first = true;
+                        for y in ys {
+                            if !first {
+                                out.push_str("---\n");
+                            }
+                            first = false;
+                            out.push_str(&serde_saphyr::to_string_with_options(&y, options)?);
+                        }
+                        out
+                    }
                 };
                 Ok(output.trim_end().to_string())
             }

--- a/test/grafana.yaml
+++ b/test/grafana.yaml
@@ -26,122 +26,122 @@ spec:
     spec:
       automountServiceAccountToken: true
       containers:
-      - env:
-        - name: METHOD
-          value: WATCH
-        - name: LABEL
-          value: grafana_dashboard
-        - name: LABEL_VALUE
-          value: '1'
-        - name: FOLDER
-          value: /tmp/dashboards
-        - name: RESOURCE
-          value: configmap
-        - name: NAMESPACE
-          value: ALL
-        - name: FOLDER_ANNOTATION
-          value: grafana_folder
-        - name: REQ_METHOD
-          value: POST
-        image: quay.io/kiwigrid/k8s-sidecar:1.24.6
-        imagePullPolicy: IfNotPresent
-        name: grafana-sc-dashboard
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          seccompProfile:
-            type: RuntimeDefault
-        volumeMounts:
-        - mountPath: /tmp/dashboards
-          name: sc-dashboard-volume
-      - env:
-        - name: METHOD
-          value: WATCH
-        - name: LABEL
-          value: grafana_datasource
-        - name: LABEL_VALUE
-          value: '1'
-        - name: FOLDER
-          value: /etc/grafana/provisioning/datasources
-        - name: RESOURCE
-          value: secret
-        - name: REQ_METHOD
-          value: POST
-        image: quay.io/kiwigrid/k8s-sidecar:1.24.6
-        imagePullPolicy: IfNotPresent
-        name: grafana-sc-datasources
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          seccompProfile:
-            type: RuntimeDefault
-        volumeMounts:
-        - mountPath: /etc/grafana/provisioning/datasources
-          name: sc-datasources-volume
-      - env:
-        - name: POD_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        - name: GF_PATHS_DATA
-          value: /var/lib/grafana/
-        - name: GF_PATHS_LOGS
-          value: /var/log/grafana
-        - name: GF_PATHS_PLUGINS
-          value: /var/lib/grafana/plugins
-        - name: GF_PATHS_PROVISIONING
-          value: /etc/grafana/provisioning
-        image: docker.io/grafana/grafana:10.1.0
-        imagePullPolicy: IfNotPresent
-        livenessProbe:
-          failureThreshold: 10
-          httpGet:
-            path: /api/health
-            port: 3000
-          initialDelaySeconds: 60
-          timeoutSeconds: 30
-        name: grafana
-        ports:
-        - containerPort: 3000
+        - env:
+            - name: METHOD
+              value: WATCH
+            - name: LABEL
+              value: grafana_dashboard
+            - name: LABEL_VALUE
+              value: "1"
+            - name: FOLDER
+              value: /tmp/dashboards
+            - name: RESOURCE
+              value: configmap
+            - name: NAMESPACE
+              value: ALL
+            - name: FOLDER_ANNOTATION
+              value: grafana_folder
+            - name: REQ_METHOD
+              value: POST
+          image: quay.io/kiwigrid/k8s-sidecar:1.24.6
+          imagePullPolicy: IfNotPresent
+          name: grafana-sc-dashboard
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /tmp/dashboards
+              name: sc-dashboard-volume
+        - env:
+            - name: METHOD
+              value: WATCH
+            - name: LABEL
+              value: grafana_datasource
+            - name: LABEL_VALUE
+              value: "1"
+            - name: FOLDER
+              value: /etc/grafana/provisioning/datasources
+            - name: RESOURCE
+              value: secret
+            - name: REQ_METHOD
+              value: POST
+          image: quay.io/kiwigrid/k8s-sidecar:1.24.6
+          imagePullPolicy: IfNotPresent
+          name: grafana-sc-datasources
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /etc/grafana/provisioning/datasources
+              name: sc-datasources-volume
+        - env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: GF_PATHS_DATA
+              value: /var/lib/grafana/
+            - name: GF_PATHS_LOGS
+              value: /var/log/grafana
+            - name: GF_PATHS_PLUGINS
+              value: /var/lib/grafana/plugins
+            - name: GF_PATHS_PROVISIONING
+              value: /etc/grafana/provisioning
+          image: docker.io/grafana/grafana:10.1.0
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 10
+            httpGet:
+              path: /api/health
+              port: 3000
+            initialDelaySeconds: 60
+            timeoutSeconds: 30
           name: grafana
-          protocol: TCP
-        - containerPort: 9094
-          name: gossip-tcp
-          protocol: TCP
-        - containerPort: 9094
-          name: gossip-udp
-          protocol: UDP
-        readinessProbe:
-          httpGet:
-            path: /api/health
-            port: 3000
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          seccompProfile:
-            type: RuntimeDefault
-        volumeMounts:
-        - mountPath: /etc/grafana/grafana.ini
-          name: config
-          subPath: grafana.ini
-        - mountPath: /var/lib/grafana
-          name: storage
-        - mountPath: /etc/grafana/provisioning/datasources/datasources.yaml
-          name: config
-          subPath: datasources.yaml
-        - mountPath: /tmp/dashboards
-          name: sc-dashboard-volume
-        - mountPath: /etc/grafana/provisioning/dashboards/sc-dashboardproviders.yaml
-          name: sc-dashboard-provider
-          subPath: provider.yaml
-        - mountPath: /etc/grafana/provisioning/datasources
-          name: sc-datasources-volume
+          ports:
+            - containerPort: 3000
+              name: grafana
+              protocol: TCP
+            - containerPort: 9094
+              name: gossip-tcp
+              protocol: TCP
+            - containerPort: 9094
+              name: gossip-udp
+              protocol: UDP
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: 3000
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /etc/grafana/grafana.ini
+              name: config
+              subPath: grafana.ini
+            - mountPath: /var/lib/grafana
+              name: storage
+            - mountPath: /etc/grafana/provisioning/datasources/datasources.yaml
+              name: config
+              subPath: datasources.yaml
+            - mountPath: /tmp/dashboards
+              name: sc-dashboard-volume
+            - mountPath: /etc/grafana/provisioning/dashboards/sc-dashboardproviders.yaml
+              name: sc-dashboard-provider
+              subPath: provider.yaml
+            - mountPath: /etc/grafana/provisioning/datasources
+              name: sc-datasources-volume
       enableServiceLinks: true
       securityContext:
         fsGroup: 472
@@ -150,15 +150,15 @@ spec:
         runAsUser: 472
       serviceAccountName: promstack-grafana
       volumes:
-      - configMap:
-          name: promstack-grafana
-        name: config
-      - emptyDir: {}
-        name: storage
-      - emptyDir: {}
-        name: sc-dashboard-volume
-      - configMap:
-          name: promstack-grafana-config-dashboards
-        name: sc-dashboard-provider
-      - emptyDir: {}
-        name: sc-datasources-volume
+        - configMap:
+            name: promstack-grafana
+          name: config
+        - emptyDir: {}
+          name: storage
+        - emptyDir: {}
+          name: sc-dashboard-volume
+        - configMap:
+            name: promstack-grafana-config-dashboards
+          name: sc-dashboard-provider
+        - emptyDir: {}
+          name: sc-datasources-volume

--- a/test/grafana.yaml
+++ b/test/grafana.yaml
@@ -26,122 +26,122 @@ spec:
     spec:
       automountServiceAccountToken: true
       containers:
-        - env:
-            - name: METHOD
-              value: WATCH
-            - name: LABEL
-              value: grafana_dashboard
-            - name: LABEL_VALUE
-              value: "1"
-            - name: FOLDER
-              value: /tmp/dashboards
-            - name: RESOURCE
-              value: configmap
-            - name: NAMESPACE
-              value: ALL
-            - name: FOLDER_ANNOTATION
-              value: grafana_folder
-            - name: REQ_METHOD
-              value: POST
-          image: quay.io/kiwigrid/k8s-sidecar:1.24.6
-          imagePullPolicy: IfNotPresent
-          name: grafana-sc-dashboard
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
-            seccompProfile:
-              type: RuntimeDefault
-          volumeMounts:
-            - mountPath: /tmp/dashboards
-              name: sc-dashboard-volume
-        - env:
-            - name: METHOD
-              value: WATCH
-            - name: LABEL
-              value: grafana_datasource
-            - name: LABEL_VALUE
-              value: "1"
-            - name: FOLDER
-              value: /etc/grafana/provisioning/datasources
-            - name: RESOURCE
-              value: secret
-            - name: REQ_METHOD
-              value: POST
-          image: quay.io/kiwigrid/k8s-sidecar:1.24.6
-          imagePullPolicy: IfNotPresent
-          name: grafana-sc-datasources
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
-            seccompProfile:
-              type: RuntimeDefault
-          volumeMounts:
-            - mountPath: /etc/grafana/provisioning/datasources
-              name: sc-datasources-volume
-        - env:
-            - name: POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-            - name: GF_PATHS_DATA
-              value: /var/lib/grafana/
-            - name: GF_PATHS_LOGS
-              value: /var/log/grafana
-            - name: GF_PATHS_PLUGINS
-              value: /var/lib/grafana/plugins
-            - name: GF_PATHS_PROVISIONING
-              value: /etc/grafana/provisioning
-          image: docker.io/grafana/grafana:10.1.0
-          imagePullPolicy: IfNotPresent
-          livenessProbe:
-            failureThreshold: 10
-            httpGet:
-              path: /api/health
-              port: 3000
-            initialDelaySeconds: 60
-            timeoutSeconds: 30
+      - env:
+        - name: METHOD
+          value: WATCH
+        - name: LABEL
+          value: grafana_dashboard
+        - name: LABEL_VALUE
+          value: "1"
+        - name: FOLDER
+          value: /tmp/dashboards
+        - name: RESOURCE
+          value: configmap
+        - name: NAMESPACE
+          value: ALL
+        - name: FOLDER_ANNOTATION
+          value: grafana_folder
+        - name: REQ_METHOD
+          value: POST
+        image: quay.io/kiwigrid/k8s-sidecar:1.24.6
+        imagePullPolicy: IfNotPresent
+        name: grafana-sc-dashboard
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /tmp/dashboards
+          name: sc-dashboard-volume
+      - env:
+        - name: METHOD
+          value: WATCH
+        - name: LABEL
+          value: grafana_datasource
+        - name: LABEL_VALUE
+          value: "1"
+        - name: FOLDER
+          value: /etc/grafana/provisioning/datasources
+        - name: RESOURCE
+          value: secret
+        - name: REQ_METHOD
+          value: POST
+        image: quay.io/kiwigrid/k8s-sidecar:1.24.6
+        imagePullPolicy: IfNotPresent
+        name: grafana-sc-datasources
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /etc/grafana/provisioning/datasources
+          name: sc-datasources-volume
+      - env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: GF_PATHS_DATA
+          value: /var/lib/grafana/
+        - name: GF_PATHS_LOGS
+          value: /var/log/grafana
+        - name: GF_PATHS_PLUGINS
+          value: /var/lib/grafana/plugins
+        - name: GF_PATHS_PROVISIONING
+          value: /etc/grafana/provisioning
+        image: docker.io/grafana/grafana:10.1.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /api/health
+            port: 3000
+          initialDelaySeconds: 60
+          timeoutSeconds: 30
+        name: grafana
+        ports:
+        - containerPort: 3000
           name: grafana
-          ports:
-            - containerPort: 3000
-              name: grafana
-              protocol: TCP
-            - containerPort: 9094
-              name: gossip-tcp
-              protocol: TCP
-            - containerPort: 9094
-              name: gossip-udp
-              protocol: UDP
-          readinessProbe:
-            httpGet:
-              path: /api/health
-              port: 3000
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
-            seccompProfile:
-              type: RuntimeDefault
-          volumeMounts:
-            - mountPath: /etc/grafana/grafana.ini
-              name: config
-              subPath: grafana.ini
-            - mountPath: /var/lib/grafana
-              name: storage
-            - mountPath: /etc/grafana/provisioning/datasources/datasources.yaml
-              name: config
-              subPath: datasources.yaml
-            - mountPath: /tmp/dashboards
-              name: sc-dashboard-volume
-            - mountPath: /etc/grafana/provisioning/dashboards/sc-dashboardproviders.yaml
-              name: sc-dashboard-provider
-              subPath: provider.yaml
-            - mountPath: /etc/grafana/provisioning/datasources
-              name: sc-datasources-volume
+          protocol: TCP
+        - containerPort: 9094
+          name: gossip-tcp
+          protocol: TCP
+        - containerPort: 9094
+          name: gossip-udp
+          protocol: UDP
+        readinessProbe:
+          httpGet:
+            path: /api/health
+            port: 3000
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /etc/grafana/grafana.ini
+          name: config
+          subPath: grafana.ini
+        - mountPath: /var/lib/grafana
+          name: storage
+        - mountPath: /etc/grafana/provisioning/datasources/datasources.yaml
+          name: config
+          subPath: datasources.yaml
+        - mountPath: /tmp/dashboards
+          name: sc-dashboard-volume
+        - mountPath: /etc/grafana/provisioning/dashboards/sc-dashboardproviders.yaml
+          name: sc-dashboard-provider
+          subPath: provider.yaml
+        - mountPath: /etc/grafana/provisioning/datasources
+          name: sc-datasources-volume
       enableServiceLinks: true
       securityContext:
         fsGroup: 472
@@ -150,15 +150,15 @@ spec:
         runAsUser: 472
       serviceAccountName: promstack-grafana
       volumes:
-        - configMap:
-            name: promstack-grafana
-          name: config
-        - emptyDir: {}
-          name: storage
-        - emptyDir: {}
-          name: sc-dashboard-volume
-        - configMap:
-            name: promstack-grafana-config-dashboards
-          name: sc-dashboard-provider
-        - emptyDir: {}
-          name: sc-datasources-volume
+      - configMap:
+          name: promstack-grafana
+        name: config
+      - emptyDir: {}
+        name: storage
+      - emptyDir: {}
+        name: sc-dashboard-volume
+      - configMap:
+          name: promstack-grafana-config-dashboards
+        name: sc-dashboard-provider
+      - emptyDir: {}
+        name: sc-datasources-volume

--- a/test/yq.test.bats
+++ b/test/yq.test.bats
@@ -105,7 +105,7 @@
 
 @test "multidoc-jq-output-to-yaml" {
   run lq '.[].metadata.labels' -y test/deploy.yaml
-  echo "$output" && echo "$output" | rg -U '\- null\n- null\n- null\n- app: controller\n- app: controller'
+  echo "$output" && echo "$output" | rg -U 'null\n---\nnull\n---\nnull\n---\napp: controller\n---\napp: controller'
 }
 
 @test "split-yaml-multi-to-yaml" {


### PR DESCRIPTION
mostly non-breaking (2 tiny stylistic output things in tests).

notes (most got resolved during development)

1. list output seems to force more `---` document separators, but it seems pretty sensible
2. compact list output seems missing - raised in https://github.com/bourumir-wyngs/serde-saphyr/issues/86
3. multidoc with options seems slightly awkward since no helper fn for it - asked in https://github.com/bourumir-wyngs/serde-saphyr/issues/87
4. struggling to use readers with multiple and options, maybe i have to inline [from_multiple_with_options](https://docs.rs/serde-saphyr/latest/serde_saphyr/fn.from_multiple_with_options.html) for a [`from_reader_with_options`](https://docs.rs/serde-saphyr/latest/serde_saphyr/fn.from_reader_with_options.html) or maybe they need a combinatorial `from_reader_multiple_with_options`..

1 is no problem really. 4. can be worked around at the cost of some internal buffering, asking upstream about 2 + 3.

otherwise it's nicer in many ways. not having to deal with `singleton_map_recursive` is nice.